### PR TITLE
Add support for report rate toggle and Reapply high touch sampling rate after turning the screen back on

### DIFF
--- a/drivers/input/touchscreen/goodix_berlin_driver/goodix_brl_hw.c
+++ b/drivers/input/touchscreen/goodix_berlin_driver/goodix_brl_hw.c
@@ -1436,6 +1436,23 @@ exit:
 	return ret;
 }
 
+#define GOODIX_HIGH_RATE_CMD		0xC0
+static int brl_switch_report_rate(struct goodix_ts_core *cd, bool on)
+{
+	struct goodix_ts_cmd cmd;
+
+	cmd.cmd = GOODIX_HIGH_RATE_CMD;
+	cmd.len = 5;
+	cmd.data[0] = (on == true) ? 1 : 0;
+	if (cd->hw_ops->send_cmd(cd, &cmd)) {
+		ts_err("failed send report rate cmd, on = %d", on);
+		return -EINVAL;
+	}
+	ts_info("reprot rate switch: %s", (on == true) ? "480HZ" : "240HZ");
+
+	return 0;
+}
+
 #define GOODIX_CMD_RAWDATA	2
 #define GOODIX_CMD_COORD	0
 static int brl_get_capacitance_data(struct goodix_ts_core *cd,
@@ -1548,6 +1565,7 @@ static struct goodix_ts_hw_ops brl_hw_ops = {
 	.after_event_handler = brl_after_event_handler,
 	.get_capacitance_data = brl_get_capacitance_data,
 	.set_coor_mode = brl_set_coor_mode,
+	.switch_report_rate = brl_switch_report_rate,
 };
 
 struct goodix_ts_hw_ops *goodix_get_hw_ops(void)

--- a/drivers/input/touchscreen/goodix_berlin_driver/goodix_ts_core.c
+++ b/drivers/input/touchscreen/goodix_berlin_driver/goodix_ts_core.c
@@ -771,6 +771,40 @@ static ssize_t goodix_ts_debug_log_store(struct device *dev,
 	return count;
 }
 
+/* report_rate show */
+static ssize_t goodix_ts_report_rate_show(struct device *dev,
+				struct device_attribute *attr, char *buf)
+{
+	struct goodix_ts_core *core_data = dev_get_drvdata(dev);
+	int r = 0;
+
+	r = snprintf(buf, PAGE_SIZE, "touch report rate::%s\n",
+			core_data->report_rate == 240 ?
+			"240HZ" : "480HZ");
+
+	return r;
+}
+
+/* report_rate_store */
+static ssize_t goodix_ts_report_rate_store(struct device *dev,
+					struct device_attribute *attr,
+					const char *buf, size_t count)
+{
+	struct goodix_ts_core *core_data = dev_get_drvdata(dev);
+
+	if (!buf || count <= 0)
+		return -EINVAL;
+
+	if (buf[0] != '0') {
+		core_data->report_rate = 480;
+		core_data->hw_ops->switch_report_rate(core_data, true);
+	} else {
+		core_data->report_rate = 240;
+		core_data->hw_ops->switch_report_rate(core_data, false);
+	}
+	return count;
+}
+
 static DEVICE_ATTR(driver_info, 0440,
 		driver_info_show, NULL);
 static DEVICE_ATTR(chip_info, 0440,
@@ -789,6 +823,7 @@ static DEVICE_ATTR(esd_info, 0664,
 		goodix_ts_esd_info_show, goodix_ts_esd_info_store);
 static DEVICE_ATTR(debug_log, 0664,
 		goodix_ts_debug_log_show, goodix_ts_debug_log_store);
+static DEVICE_ATTR_RW(goodix_ts_report_rate);
 
 static struct attribute *sysfs_attrs[] = {
 	&dev_attr_driver_info.attr,
@@ -800,6 +835,7 @@ static struct attribute *sysfs_attrs[] = {
 	&dev_attr_irq_info.attr,
 	&dev_attr_esd_info.attr,
 	&dev_attr_debug_log.attr,
+	&dev_attr_goodix_ts_report_rate.attr,
 	NULL,
 };
 
@@ -2579,6 +2615,7 @@ static int goodix_ts_probe(struct platform_device *pdev)
 	goodix_tools_init();
 
 	core_data->init_stage = CORE_INIT_STAGE1;
+	core_data->report_rate = 240;
 	goodix_modules.core_data = core_data;
 	core_module_prob_sate = CORE_MODULE_PROB_SUCCESS;
 

--- a/drivers/input/touchscreen/goodix_berlin_driver/goodix_ts_core.c
+++ b/drivers/input/touchscreen/goodix_berlin_driver/goodix_ts_core.c
@@ -1975,6 +1975,11 @@ out:
 	if (core_data->board_data.support_thp_fw) {
 		core_data->hw_ops->set_coor_mode(core_data);
 	}
+	/* Re-enable high sampling rate */
+	if (core_data->report_rate != 240) {
+		ts_info("Re-enable high sampling rate");
+		hw_ops->switch_report_rate(core_data, true);
+	}
 	ts_info("Resume end");
 	return 0;
 }

--- a/drivers/input/touchscreen/goodix_berlin_driver/goodix_ts_core.h
+++ b/drivers/input/touchscreen/goodix_berlin_driver/goodix_ts_core.h
@@ -464,6 +464,7 @@ struct goodix_ts_hw_ops {
 	int (*after_event_handler)(struct goodix_ts_core *cd);
 	int (*get_capacitance_data)(struct goodix_ts_core *cd,
 			struct ts_rawdata_info *info);
+	int (*switch_report_rate)(struct goodix_ts_core *cd, bool on);
 	int (*set_coor_mode)(struct goodix_ts_core *cd);
 };
 
@@ -558,6 +559,7 @@ struct goodix_ts_core {
 	struct delayed_work gesture_work;
 
 	bool nonui_enabled;
+	int report_rate;
 };
 
 /* external module structures */


### PR DESCRIPTION
This commit added the /sys/devices/platform/goodix_ts.0/goodix_ts_report_rate node.
Write 0 to disable high touch sampling rate (default).
Write any other string to enable high touch sampling rate.