### PR TITLE
Fake all Lineage-related mappings and symlinks, and jit-zygote-cache flags

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -2271,12 +2271,18 @@ static int map_files_get_link(struct dentry *dentry, struct path *path)
 
 	rc = -ENOENT;
 	vma = find_exact_vma(mm, vm_start, vm_end);
-	if (vma && vma->vm_file) {
-		*path = vma->vm_file->f_path;
-		path_get(path);
-		rc = 0;
-	}
-	mmap_read_unlock(mm);
+ 	if (vma) {
+        	if (vma->vm_file) {
+            		if (strstr(vma->vm_file->f_path.dentry->d_name.name, "lineage")) { 
+            		rc = kern_path("/dev/ashmem (deleted)", LOOKUP_FOLLOW, path);
+        	} else {
+			*path = vma->vm_file->f_path;
+			path_get(path);
+                	rc = 0;
+            		}
+        	}
+    	}
+	up_read(&mm->mmap_sem);
 
 out_mmput:
 	mmput(mm);

--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -335,6 +335,11 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 		dev = inode->i_sb->s_dev;
 		ino = inode->i_ino;
 		pgoff = ((loff_t)vma->vm_pgoff) << PAGE_SHIFT;
+        struct dentry *dentry = file->f_path.dentry;
+        if (dentry) {
+        	const char *path = (const char *)dentry->d_name.name; 
+            	if (strstr(path, "lineage")) { return; }
+            	}
 	}
 
 	start = vma->vm_start;

--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -338,7 +338,13 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
         struct dentry *dentry = file->f_path.dentry;
         if (dentry) {
         	const char *path = (const char *)dentry->d_name.name; 
-            	if (strstr(path, "lineage")) { return; }
+            	if (strstr(path, "lineage")) { 
+	  	start = vma->vm_start;
+		end = vma->vm_end;
+		show_vma_header_prefix(m, start, end, flags, pgoff, dev, ino);
+            	name = "/dev/ashmem (deleted)";
+		goto done;
+            	 	}
             	}
 	}
 

--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -318,6 +318,23 @@ static void show_vma_header_prefix(struct seq_file *m,
 	seq_putc(m, ' ');
 }
 
+static void show_vma_header_prefix_fake(struct seq_file *m,
+				   unsigned long start, unsigned long end,
+				   vm_flags_t flags, unsigned long long pgoff,
+				   dev_t dev, unsigned long ino)
+{
+	seq_setwidth(m, 25 + sizeof(void *) * 6 - 1);
+	seq_printf(m, "%08lx-%08lx %c%c%c%c %08llx %02x:%02x %lu ",
+		   start,
+		   end,
+		   flags & VM_READ ? 'r' : '-',
+		   flags & VM_WRITE ? 'w' : '-',
+		   flags & VM_EXEC ? '-' : '-',
+		   flags & VM_MAYSHARE ? 's' : 'p',
+		   pgoff,
+		   MAJOR(dev), MINOR(dev), ino);
+}
+
 static void
 show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 {
@@ -345,13 +362,19 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
             	name = "/dev/ashmem (deleted)";
 		goto done;
             	 	}
+            	if (strstr(path, "jit-zygote-cache")) { 
+	  	start = vma->vm_start;
+		end = vma->vm_end;
+		show_vma_header_prefix_fake(m, start, end, flags, pgoff, dev, ino);
+		goto bypass;
+            	 	}
             	}
 	}
 
 	start = vma->vm_start;
 	end = vma->vm_end;
 	show_vma_header_prefix(m, start, end, flags, pgoff, dev, ino);
-
+bypass:
 	/*
 	 * Print the dentry name for named mappings, and a
 	 * special [heap] marker for the heap:


### PR DESCRIPTION
Some apps check for this kind of stuff, so we do maphide to avoid detection.